### PR TITLE
Remove jutter in viewport

### DIFF
--- a/client/canvas.js
+++ b/client/canvas.js
@@ -372,7 +372,7 @@ export class ViewPort {
 
         this.height = 600;
         this.width = 800;
-        this.speed_multiplier = 2;
+        this.speed_multiplier = 1;
 
         // How large zone should be where the camera starts to
         // follow the player.
@@ -407,13 +407,13 @@ export class ViewPort {
 
         if (X < this.move_zone) {
             move_x -= 1;
-        } else if (X > this.width - this.move_zone - 96) {
+        } else if (X > this.width - this.move_zone - config.SCALE) {
             move_x += 1;
         }
 
         if (Y < this.move_zone) {
             move_y -= 1;
-        } else if (Y > this.height - this.move_zone - 96) {
+        } else if (Y > this.height - this.move_zone - config.SCALE) {
             move_y += 1;
         }
 

--- a/client/state.js
+++ b/client/state.js
@@ -160,15 +160,6 @@ class State {
     // Drawing function. This is automatically called by
     // `requestAnimationFrame`.
     draw(dt) {
-        // TODO: have a long hard think about whether this should live in draw
-        // or update?
-        this.viewport.follow(
-            dt,
-            this.player.x,
-            this.player.y,
-            this.player.vx,
-            this.player.vy,
-        );
         this.game_map.draw(dt, this.viewport, this.assets);
 
         this.player.draw(dt, this.viewport, this.assets);
@@ -268,6 +259,14 @@ class State {
         });
 
         this.player.update(dt);
+
+        this.viewport.follow(
+            dt,
+            this.player.x,
+            this.player.y,
+            this.player.vx,
+            this.player.vy,
+        );
 
         // After updating the movement, send updated position to server
         this.conn.send(this.player);


### PR DESCRIPTION
The viewport follow should happen in the `update` stage instead of the `draw` stage to avoid things going out of sync.